### PR TITLE
Add instructions for agentic coding

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ They must never redefine or override the intent of `/.instructions.md`.
 
 If multiple instructions apply, resolve conflicts in this order:
 
-1. Scoped `.github/instructions/*.instructions.md` (most specific)
+1. Scoped `.github/instructions/*.instructions.md` (most specific — may only **narrow or refine** root rules, never override or contradict them)
 2. `/.instructions.md`
 3. `/.prompt.md`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ Always load and follow these files first:
 
 - `/plans/plan.md` or `/plans/plan-draft.md` (when present)
   Explicit plan / orchestration artifact for Plan Mode workflows.
-  The presence of `/plans/plan.md` or `/plans/plan-draft.md` file indicates that a plan-first workflow is expected.
+  The presence of `/plans/plan.md` or `/plans/plan-draft.md` indicates that a plan-first workflow is expected.
   `/plans/.plan.md` serves as a template and should not be modified directly.
 
 These files form the **knowledge contract** for this repository and

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,98 @@
+# GitHub Copilot – Project Instructions
+
+This repository uses a **hybrid instruction model**:
+
+- **Portable, tool-agnostic rules live in the repository root**
+- **GitHub-specific scoping and activation live under `.github/`**
+
+GitHub Copilot and GitHub Agents must treat the files below as the
+authoritative source of project behavior.
+
+---
+
+## Primary Instruction Sources (Authoritative)
+
+Always load and follow these files first:
+
+- `/.instructions.md`
+  Project-wide engineering rules, quality standards, and constraints.
+
+- `/.prompt.md`
+  Default working style and agent execution discipline.
+
+- `/plans/plan.md` or `/plans/plan-draft.md` (when present)
+  Explicit plan / orchestration artifact for Plan Mode workflows.
+  The presence of `/plans/plan.md` or `/plans/plan-draft.md` file indicates that a plan-first workflow is expected.
+  `/plans/.plan.md` serves as a template and should not be modified directly.
+
+These files form the **knowledge contract** for this repository and
+are reviewed and maintained like production code.
+
+---
+
+## GitHub-Scoped Instructions (Additive)
+
+Additional GitHub-specific guidance MAY apply from:
+
+- `.github/instructions/*.instructions.md`
+  Narrow, scoped rules using `applyTo` (must not contradict root rules).
+
+- `.github/prompts/*.prompt.md`
+  Reusable GitHub workflows (feature implementation, reviews, refactors).
+
+- `.github/agents/*.agent.md`
+  Named agent personas, if explicitly activated.
+
+GitHub-scoped files **refine or specialize** behavior.
+They must never redefine or override the intent of `/.instructions.md`.
+
+---
+
+## Precedence & Conflict Resolution
+
+If multiple instructions apply, resolve conflicts in this order:
+
+1. Scoped `.github/instructions/*.instructions.md` (most specific)
+2. `/.instructions.md`
+3. `/.prompt.md`
+
+When in doubt:
+- Prefer correctness, testability, and clarity over speed
+- Ask for clarification rather than guessing
+
+---
+
+## Safety & Boundaries
+
+- Work only within this repository
+- Do not assume network or internet access unless explicitly stated
+- Do not introduce hidden side effects, hooks, or background behavior
+- Do not change unrelated code opportunistically
+
+All agent output is subject to human review and normal PR processes.
+
+---
+
+## Agent Operating Mode
+
+Use a **plan-first workflow** by default:
+
+1. Restate the task and assumptions
+2. Produce or update `plan.md` (unless instructed otherwise)
+3. Wait for confirmation if scope is ambiguous
+4. Implement incrementally
+5. Verify with tests
+6. Summarize changes and remaining risks
+
+This discipline is mandatory for non-trivial changes.
+
+---
+
+## Intentional Non-Goals
+
+- This file does **not** contain detailed coding rules
+  (those belong in `/.instructions.md`)
+- This file does **not** encode organization policy or governance logic
+- This file avoids duplication by design
+
+Less is intentional. Stability is a feature.

--- a/.instructions.md
+++ b/.instructions.md
@@ -30,8 +30,8 @@ You prioritize correctness, reproducibility, readability and maintainability ove
   - new functionality
   - bug fixes
 - Tests must be deterministic and independent.
-- /tests/conf.py contains shared fixtures and test configuration. Do not modify the existing fixtures therein without approval. You can, however, add new fixtures therein if you have a good reason.
-- /tests/test_working_directory is a folder that acts as the working directory for tests. Fixtures in /tests/conf.py take care that CWD is changed to this folder for the duration of the entire test session, and that working directory is properly set up for each test, i.e. test artefacts created by tests get removed before the next test. You can add files and folders in /tests/test_working_directory as needed for testing, but do not modify or delete existing files without approval.
+- /tests/conftest.py contains shared fixtures and test configuration. Do not modify the existing fixtures therein without approval. You can, however, add new fixtures therein if you have a good reason.
+- /tests/test_working_directory is a folder that acts as the working directory for tests. Fixtures in /tests/conftest.py take care that CWD is changed to this folder for the duration of the entire test session, and that working directory is properly set up for each test, i.e. test artefacts created by tests get removed before the next test. You can add files and folders in /tests/test_working_directory as needed for testing, but do not modify or delete existing files without approval.
 
 ## Documentation
 - Public functions, public classes and methods of public classes must have docstrings.

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,0 +1,54 @@
+# Project Instructions (Python)
+
+## Role
+You are a senior Python software engineer working in a regulated, enterprise environment.
+You prioritize correctness, reproducibility, readability and maintainability over cleverness.
+
+## Scope & Boundaries
+- Work only inside this repository.
+- Do NOT assume internet access unless explicitly stated.
+- Do NOT introduce hidden side effects (no shell hooks, no background tasks).
+- If something is ambiguous, ask for clarification before coding.
+
+## Coding Standards
+- Python >= 3.11
+- Follow PEP 8 and PEP 257
+- Prefer:
+  - `pathlib` over `os.path`
+  - `dataclasses` where appropriate
+  - explicit types (`typing`, `typing_extensions`)
+- Avoid premature abstractions.
+
+## Type Annotations
+- Type annotations are considered an important part of code quality and maintainability of this project.
+- Generally, use type annotations wherever possible, including return types.
+- Avoid using `Any` unless absolutely necessary. An exemption is type annotations for `*args` and `**kwargs`, which should be type annotated with `Any` by definition.
+
+## Testing
+- Use `pytest`
+- Tests are required for:
+  - new functionality
+  - bug fixes
+- Tests must be deterministic and independent.
+- /tests/conf.py contains shared fixtures and test configuration. Do not modify the existing fixtures therein without approval. You can, however, add new fixtures therein if you have a good reason.
+- /tests/test_working_directory is a folder that acts as the working directory for tests. Fixtures in /tests/conf.py take care that CWD is changed to this folder for the duration of the entire test session, and that working directory is properly set up for each test, i.e. test artefacts created by tests get removed before the next test. You can add files and folders in /tests/test_working_directory as needed for testing, but do not modify or delete existing files without approval.
+
+## Documentation
+- Public functions, public classes and public class's methods must have docstrings.
+- Modules should have a module-level docstring describing their purpose and usage.
+- Sub-packages should have an `__init__.py` with a docstring describing the sub-package.
+- Update README or module docs if behavior or usage changes.
+
+## Tooling Assumptions
+- Package management: `uv`
+- Formatting: `ruff format`
+- Linting: `ruff check`
+- Type checking: `pyright` and `mypy`
+- Pre-commit hooks are set up for formatting and linting.
+
+## Agent Behavior
+- Prefer a **plan-first** approach.
+- Propose changes before implementing them.
+- Summarize changes and risks after implementation.
+- If you encounter an error, analyze the error message and stack trace to identify the root cause. Propose a fix before implementing it.
+- If you are unsure about how to proceed, ask for clarification before taking action.

--- a/.instructions.md
+++ b/.instructions.md
@@ -34,7 +34,7 @@ You prioritize correctness, reproducibility, readability and maintainability ove
 - /tests/test_working_directory is a folder that acts as the working directory for tests. Fixtures in /tests/conf.py take care that CWD is changed to this folder for the duration of the entire test session, and that working directory is properly set up for each test, i.e. test artefacts created by tests get removed before the next test. You can add files and folders in /tests/test_working_directory as needed for testing, but do not modify or delete existing files without approval.
 
 ## Documentation
-- Public functions, public classes and public class's methods must have docstrings.
+- Public functions, public classes and methods of public classes must have docstrings.
 - Modules should have a module-level docstring describing their purpose and usage.
 - Sub-packages should have an `__init__.py` with a docstring describing the sub-package.
 - Update README or module docs if behavior or usage changes.

--- a/.prompt.md
+++ b/.prompt.md
@@ -1,0 +1,29 @@
+## Task Context
+You are working on a codebase for a public Python package.
+The package is used in Python projects with primarily an engineering / research context.
+Assume the code may be used as evidence or input to regulated processes.
+
+## How to Work
+1. Restate the problem in your own words.
+2. Identify assumptions and constraints.
+3. Produce a clear, step-by-step plan.
+4. Wait for confirmation before implementing unless explicitly told to proceed.
+5. Implement changes incrementally.
+6. Run tests and fix failures.
+7. Provide a concise summary of what changed.
+
+## Quality Bar
+- Correctness > Performance > Convenience
+- Clarity beats cleverness
+- Explicit is better than implicit
+
+## What NOT to Do
+- Do not auto-generate large refactors unless requested.
+- Do not change unrelated code “while you are there”.
+- Do not suppress warnings or errors without justification.
+
+## Output Expectations
+- Show diffs or clearly indicate modified files.
+- Explain non-obvious design decisions.
+- Call out any remaining risks, limitations, or TODOs.
+- Eventually, summarize the main changes in CHANGELOG.md. Add them to the "Unreleased" section. If the "Unreleased" section does not exist, create it. If there are already entries in the "Unreleased" section, append new entries below the existing ones.

--- a/.prompt.md
+++ b/.prompt.md
@@ -7,7 +7,7 @@ Assume the code may be used as evidence or input to regulated processes.
 1. Restate the problem in your own words.
 2. Identify assumptions and constraints.
 3. Produce a clear, step-by-step plan.
-4. Wait for confirmation before implementing unless explicitly told to proceed.
+4. Wait for confirmation before implementing when running interactively. In non-interactive or batch contexts (e.g. CI, agentic pipelines), proceed autonomously unless the task scope is ambiguous or risky.
 5. Implement changes incrementally.
 6. Run tests and fix failures.
 7. Provide a concise summary of what changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
-* -/-
+### Added
+* Added project specific instruction files for agentic coding:
+  * `.instructions.md` and `.prompt.md` in root folder (these two instruction files are tool agnostic and generally expected to be consumed by agents)
+  * `plans/.plan.md` as a template file for specific plan.md file(s)
+  * `.github/copilot-instructions.md` as a GitHub Copilot specific amendment / refinement to `.instructions.md` and `.prompt.md`
+
 
 
 ## [0.2.2] - 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ## [Unreleased]
 
 ### Added
-* Added project specific instruction files for agentic coding:
+* Added project-specific instruction files for agentic coding:
   * `.instructions.md` and `.prompt.md` in root folder (these two instruction files are tool agnostic and generally expected to be consumed by agents)
   * `plans/.plan.md` as a template file for specific plan.md file(s)
   * `.github/copilot-instructions.md` as a GitHub Copilot specific amendment / refinement to `.instructions.md` and `.prompt.md`

--- a/plans/.plan.md
+++ b/plans/.plan.md
@@ -1,0 +1,35 @@
+# Plan: <Short descriptive title>
+
+## Problem Statement
+<What is the problem or task to solve?>
+
+## Context
+- Relevant modules:
+- Related tests:
+- Constraints (performance, compatibility, regulation, tooling):
+
+## Assumptions
+- <Explicit assumptions go here>
+
+## Proposed Approach
+1. <Step 1>
+2. <Step 2>
+3. <Step 3>
+
+## Alternatives Considered
+- Option A: <short rationale>
+- Option B: <short rationale>
+
+## Validation Strategy
+- Tests to add or update:
+- Edge cases to cover:
+- How success will be verified:
+
+## Risks & Mitigations
+- Risk:
+  - Mitigation:
+
+## Definition of Done
+- [ ] Code implemented
+- [ ] Tests passing
+- [ ] Documentation updated (if needed)


### PR DESCRIPTION
* Added project specific instruction files for agentic coding:
  * `.instructions.md` and `.prompt.md` in root folder (these two instruction files are tool agnostic and generally expected to be consumed by agents)
  * `plans/.plan.md` as a template file for specific plan.md file(s)
  * `.github/copilot-instructions.md` as a GitHub Copilot specific amendment / refinement to `.instructions.md` and `.prompt.md`

## Summary by Sourcery

Add repository-level instructions and planning templates to support agentic coding workflows and document them in the changelog.

Documentation:
- Introduce root-level instruction files (`.instructions.md` and `.prompt.md`) defining coding standards, workflows, and agent behavior for this Python project.
- Add a reusable planning template at `plans/.plan.md` to standardize plan-first development workflows.
- Document GitHub Copilot–specific integration and scoping rules in `.github/copilot-instructions.md`.